### PR TITLE
リファクタリング: 基底クラス抽出、バグ修正、Javaイディオムのモダン化

### DIFF
--- a/app/src/main/java/protobufhandler/AppEditorProvider.java
+++ b/app/src/main/java/protobufhandler/AppEditorProvider.java
@@ -10,19 +10,17 @@ import protobufhandler.view.AppRequestEditorView;
 import protobufhandler.view.AppResponseEditorView;
 
 import java.util.List;
-import java.util.ArrayList;
 
 public class AppEditorProvider {
     private final MontoyaApi api;
     private final String editorCaption;
-    public static final List<String> ENABLE_EDITOR_CONTENT_TYPE = new ArrayList<String>() {
-        {
-            add("application/x-protobuf");
-            add("application/protobuf");
-            add("application/grpc-web+proto");
-            add("application/grpc");
-        }
-    };
+
+    public static final List<String> ENABLE_EDITOR_CONTENT_TYPE = List.of(
+            "application/x-protobuf",
+            "application/protobuf",
+            "application/grpc-web+proto",
+            "application/grpc"
+    );
 
     public AppEditorProvider(MontoyaApi api, String editorCaption) {
         this.api = api;

--- a/app/src/main/java/protobufhandler/AppHandler.java
+++ b/app/src/main/java/protobufhandler/AppHandler.java
@@ -30,7 +30,6 @@ public class AppHandler implements HttpHandler {
 
     @Override
     public RequestToBeSentAction handleHttpRequestToBeSent(HttpRequestToBeSent requestToBeSent) {
-        // Protobuf Handler がサポートするツールか判定
         if (!requestToBeSent.toolSource().isFromTool(AppModel.RULE_TARGE_TOOL_TYPE)) {
             return RequestToBeSentAction.continueWith(requestToBeSent);
         }
@@ -44,15 +43,10 @@ public class AppHandler implements HttpHandler {
         String requestToString = headerToString.concat(bodyToString);
 
         for (AppModel rule : handlingRules) {
-            if(!rule.isEnabled()) { continue; }
-            if(!rule.isRequestHandling()) { continue; }
-            if(!rule.getToolScope().contains(requestToBeSent.toolSource().toolType().toolName())) { continue; }
-            if(!requestToString.contains(rule.getScope())) {
-                logging.logToOutput("リクエストがスコープとマッチしませんでした。");
-                logging.logToOutput("Request: %s".formatted(requestToBeSent.pathWithoutQuery()));
-                logging.logToOutput("Scope: %s\n".formatted(rule.getScope()));
-                continue;
-            }
+            if (!rule.isEnabled()) { continue; }
+            if (!rule.isRequestHandling()) { continue; }
+            if (!rule.getToolScope().contains(requestToBeSent.toolSource().toolType().toolName())) { continue; }
+            if (!requestToString.contains(rule.getScope())) { continue; }
 
             try {
                 Descriptor descriptor = rule.getDescriptor();
@@ -62,10 +56,8 @@ public class AppHandler implements HttpHandler {
 
             } catch (Exception e) {
                 logging.logToError(e);
-                logging.logToOutput("Protobufメッセージに変換することができませんでした。");
-                logging.logToOutput("Request: %s".formatted(requestToBeSent.pathWithoutQuery()));
-                logging.logToOutput("Scope: %s".formatted(rule.getScope()));
-                logging.logToOutput("Message Type: %s\n".formatted(rule.getDescriptor().getName()));
+                logging.logToOutput("Protobufメッセージに変換することができませんでした。 Request: %s, Scope: %s, Message Type: %s".formatted(
+                        requestToBeSent.pathWithoutQuery(), rule.getScope(), rule.getDescriptor().getName()));
             }
         }
 
@@ -75,42 +67,35 @@ public class AppHandler implements HttpHandler {
     @Override
     public ResponseReceivedAction handleHttpResponseReceived(HttpResponseReceived responseReceived) {
         HttpRequest initiatingRequest = responseReceived.initiatingRequest();
-        if(!initiatingRequest.isInScope()) {
+        if (!initiatingRequest.isInScope()) {
             return ResponseReceivedAction.continueWith(responseReceived);
         }
 
         for (AppModel rule : handlingRules) {
-            if(!rule.isEnabled()) { continue; }
-            if(rule.isRequestHandling()) { continue; }
-            if(!rule.getToolScope().contains(responseReceived.toolSource().toolType().toolName())) { continue; }
-            if(!initiatingRequest.contains(rule.getScope(), false)) {
-                logging.logToOutput("ベースリクエストがスコープとマッチしませんでした。");
-                logging.logToOutput("Request: %s".formatted(initiatingRequest.pathWithoutQuery()));
-                logging.logToOutput("Scope: %s\n".formatted(rule.getScope()));
-                continue;
-            }
+            if (!rule.isEnabled()) { continue; }
+            if (rule.isRequestHandling()) { continue; }
+            if (!rule.getToolScope().contains(responseReceived.toolSource().toolType().toolName())) { continue; }
+            if (!initiatingRequest.contains(rule.getScope(), false)) { continue; }
 
             try {
                 Descriptor descriptor = rule.getDescriptor();
-                HttpResponse response = responseReceived;
+                HttpResponse response;
 
-                if(rule.getReplaceResponseBody().isBlank()) {
-                    DynamicMessage message = Protobuffer.jsonToProtobuf(new String(responseReceived.body().getBytes(), StandardCharsets.UTF_8), descriptor);
+                if (rule.getReplaceResponseBody().isBlank()) {
+                    DynamicMessage message = Protobuffer.jsonToProtobuf(
+                            new String(responseReceived.body().getBytes(), StandardCharsets.UTF_8), descriptor);
                     response = responseReceived.withBody(ByteArray.byteArray(message.toByteArray()));
-
-                } else { // Optionalのレスポンスボディの書き換え。空じゃなかったら実行する
+                } else {
                     DynamicMessage message = Protobuffer.jsonToProtobuf(rule.getReplaceResponseBody(), descriptor);
                     response = responseReceived.withBody(ByteArray.byteArray(message.toByteArray()));
                 }
-                
+
                 return ResponseReceivedAction.continueWith(response);
 
             } catch (Exception e) {
                 logging.logToError(e);
-                logging.logToOutput("Protobufメッセージに変換することができませんでした。");
-                logging.logToOutput("Request: %s".formatted(initiatingRequest.pathWithoutQuery()));
-                logging.logToOutput("Scope: %s".formatted(rule.getScope()));
-                logging.logToOutput("Message Type: %s\n".formatted(rule.getDescriptor().getName()));
+                logging.logToOutput("Protobufメッセージに変換することができませんでした。 Request: %s, Scope: %s, Message Type: %s".formatted(
+                        initiatingRequest.pathWithoutQuery(), rule.getScope(), rule.getDescriptor().getName()));
             }
         }
 

--- a/app/src/main/java/protobufhandler/model/AppModel.java
+++ b/app/src/main/java/protobufhandler/model/AppModel.java
@@ -134,7 +134,7 @@ public class AppModel {
     }
 
     public void clearToolScope() {
-        this.cachedMessageTypes.clear();
+        this.toolScope.clear();
     }
 
 }

--- a/app/src/main/java/protobufhandler/util/Protobuffer.java
+++ b/app/src/main/java/protobufhandler/util/Protobuffer.java
@@ -4,8 +4,8 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.TreeMap;
 
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
@@ -29,7 +29,6 @@ public class Protobuffer {
     public static String decodeRaw(byte[] message) throws InvalidProtocolBufferException {
         UnknownFieldSet.Builder builder = UnknownFieldSet.newBuilder();
         builder.mergeFrom(message);
-
         return builder.build().toString();
     }
 
@@ -42,30 +41,23 @@ public class Protobuffer {
 
     // descriptor_setからmessageTypeを取得する
     public static List<Descriptor> getMessageTypesFromProtoFile(String protoDescPath) throws IOException, Descriptors.DescriptorValidationException {
-        FileInputStream protoFis = new FileInputStream(protoDescPath);
-        BufferedInputStream bufferedInputStream = new BufferedInputStream(protoFis);
-        FileDescriptorSet set = FileDescriptorSet.parseFrom(bufferedInputStream);
-        protoFis.close();
-        bufferedInputStream.close();
+        FileDescriptorSet set;
+        try (FileInputStream fis = new FileInputStream(protoDescPath);
+             BufferedInputStream bis = new BufferedInputStream(fis)) {
+            set = FileDescriptorSet.parseFrom(bis);
+        }
 
-        List<Descriptor> descriptors = new ArrayList<Descriptor>();
-        List<FileDescriptor> dependenciesDescriptors = new ArrayList<FileDescriptor>();
+        List<Descriptor> descriptors = new ArrayList<>();
+        List<FileDescriptor> dependencyDescriptors = new ArrayList<>();
         for (FileDescriptorProto descriptorProto : set.getFileList()) {
-            FileDescriptor dependencieDescriptor = FileDescriptor.buildFrom(descriptorProto, dependenciesDescriptors.toArray(new FileDescriptor[dependenciesDescriptors.size()]));
-            descriptors.addAll(dependencieDescriptor.getMessageTypes());
-            dependenciesDescriptors.add(dependencieDescriptor);
+            FileDescriptor fileDescriptor = FileDescriptor.buildFrom(
+                    descriptorProto,
+                    dependencyDescriptors.toArray(new FileDescriptor[0]));
+            descriptors.addAll(fileDescriptor.getMessageTypes());
+            dependencyDescriptors.add(fileDescriptor);
         }
 
-        return sortMessageType(descriptors);
-    }
-
-    private static List<Descriptor> sortMessageType(List<Descriptor> descriptors) {
-        TreeMap<String, Descriptor> sortedTreeMap = new TreeMap<String, Descriptor>();
-        for(Descriptor descriptor : descriptors) {
-            sortedTreeMap.put(descriptor.getName(), descriptor);
-        }
-        List<Descriptor> sortedDescriptors = new ArrayList<Descriptor>(sortedTreeMap.values());
-
-        return sortedDescriptors;
+        descriptors.sort(Comparator.comparing(Descriptor::getName));
+        return descriptors;
     }
 }

--- a/app/src/main/java/protobufhandler/view/AbstractEditorView.java
+++ b/app/src/main/java/protobufhandler/view/AbstractEditorView.java
@@ -1,0 +1,194 @@
+package protobufhandler.view;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.core.ByteArray;
+import burp.api.montoya.http.message.HttpRequestResponse;
+import burp.api.montoya.logging.Logging;
+import burp.api.montoya.ui.Selection;
+import burp.api.montoya.ui.editor.RawEditor;
+import burp.api.montoya.ui.editor.extension.EditorCreationContext;
+import protobufhandler.AppEditorProvider;
+import protobufhandler.util.Protobuffer;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.Color;
+import java.awt.Component;
+
+import javax.swing.JPanel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JFileChooser;
+import javax.swing.BoxLayout;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.protobuf.Descriptors.Descriptor;
+
+/**
+ * Request/Response EditorView の共通ロジックを持つ基底クラス。
+ * descファイルの読み込み、メッセージタイプ選択、decode_raw表示を共通化する。
+ */
+public abstract class AbstractEditorView {
+    protected final JPanel mainEditorPanel;
+    protected final JComboBox<String> messageTypeComboBox;
+    protected final RawEditor editor;
+    protected final String editorCaption;
+    protected final Logging logging;
+    protected HttpRequestResponse requestResponse;
+    protected Map<String, Descriptor> messageTypes;
+
+    protected AbstractEditorView(MontoyaApi api, EditorCreationContext creationContext, String editorCaption) {
+        this.logging = api.logging();
+        this.editorCaption = editorCaption;
+        this.messageTypes = new HashMap<>();
+
+        editor = api.userInterface().createRawEditor();
+        editor.setEditable(false);
+
+        mainEditorPanel = new JPanel(new BorderLayout());
+        JLabel selectedProtoPathLabel = new JLabel("選択されていません");
+        selectedProtoPathLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
+
+        messageTypeComboBox = new JComboBox<>();
+        messageTypeComboBox.setEnabled(false);
+
+        JButton protoChooseBtn = new JButton("Choose");
+        JButton resetBtn = new JButton("Reset");
+        JButton jsonDecodeBtn = new JButton("Decode");
+        jsonDecodeBtn.setEnabled(false);
+        resetBtn.setBackground(new Color(251, 180, 196));
+
+        JFileChooser protoChooser = new JFileChooser();
+        protoChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+        protoChooser.setFileFilter(new FileNameExtensionFilter("Proto Descriptor files (*.desc)", "desc"));
+
+        protoChooseBtn.addActionListener(event -> {
+            int actionAns = protoChooser.showOpenDialog(null);
+            if (actionAns == JFileChooser.APPROVE_OPTION) {
+                messageTypes = new HashMap<>();
+                messageTypeComboBox.removeAllItems();
+                String selectedPath = protoChooser.getSelectedFile().getAbsolutePath();
+                try {
+                    List<Descriptor> descriptors = Protobuffer.getMessageTypesFromProtoFile(selectedPath);
+                    for (Descriptor descriptor : descriptors) {
+                        messageTypes.put(descriptor.getName(), descriptor);
+                        messageTypeComboBox.addItem(descriptor.getName());
+                    }
+                } catch (Exception e) {
+                    logging.logToError(e);
+                    logging.logToOutput("Protobuf file の読み込みに失敗しました。File: %s".formatted(selectedPath));
+                }
+
+                jsonDecodeBtn.setEnabled(true);
+                messageTypeComboBox.setEnabled(true);
+                selectedProtoPathLabel.setText(selectedPath);
+            }
+        });
+
+        resetBtn.addActionListener(event -> {
+            jsonDecodeBtn.setEnabled(false);
+            messageTypeComboBox.removeAllItems();
+            messageTypeComboBox.setEnabled(false);
+            selectedProtoPathLabel.setText("選択されていません");
+            showRawBody();
+        });
+
+        jsonDecodeBtn.addActionListener(event -> {
+            Descriptor descriptor = messageTypes.get(messageTypeComboBox.getSelectedItem());
+            try {
+                String json = Protobuffer.protobufToJson(getBodyBytes(), descriptor);
+                onDecodeSuccess(json);
+            } catch (Exception e) {
+                logging.logToError(e);
+                editor.setContents(ByteArray.byteArray("Failed to parse input."));
+            }
+        });
+
+        JPanel protoPathPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        protoPathPanel.add(selectedProtoPathLabel);
+        protoPathPanel.add(protoChooseBtn);
+        protoPathPanel.add(resetBtn);
+
+        JPanel protoDecodePanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        protoDecodePanel.add(messageTypeComboBox);
+        protoDecodePanel.add(jsonDecodeBtn);
+
+        JPanel protobufFormPanel = new JPanel();
+        protobufFormPanel.setLayout(new BoxLayout(protobufFormPanel, BoxLayout.Y_AXIS));
+        protobufFormPanel.add(protoPathPanel);
+        protobufFormPanel.add(protoDecodePanel);
+
+        mainEditorPanel.add(protobufFormPanel, BorderLayout.NORTH);
+        mainEditorPanel.add(editor.uiComponent(), BorderLayout.CENTER);
+    }
+
+    /** bodyのバイト列を取得する（Request/Responseで異なる） */
+    protected abstract byte[] getBodyBytes();
+
+    /** Decode成功時のeditor設定（Requestはeditable、Responseはread-only） */
+    protected abstract void onDecodeSuccess(String json);
+
+    /** Content-Typeヘッダの値を取得する */
+    protected abstract String getContentType();
+
+    /** raw decode表示 */
+    protected void showRawBody() {
+        try {
+            String decodedBody = Protobuffer.decodeRaw(getBodyBytes());
+            editor.setContents(ByteArray.byteArray(decodedBody));
+            editor.setEditable(false);
+        } catch (Exception e) {
+            editor.setContents(ByteArray.byteArray(getBodyBytes()));
+            editor.setEditable(false);
+        }
+    }
+
+    /** メッセージタイプが選択済みなら型付きデコード、未選択ならraw decode */
+    protected void decodeAndDisplay() {
+        Object comboBoxObj = messageTypeComboBox.getSelectedItem();
+        if (comboBoxObj == null) {
+            showRawBody();
+        } else {
+            Descriptor descriptor = messageTypes.get(comboBoxObj);
+            try {
+                String json = Protobuffer.protobufToJson(getBodyBytes(), descriptor);
+                onDecodeSuccess(json);
+            } catch (Exception e) {
+                showRawBody();
+            }
+        }
+    }
+
+    /** Content-Typeがprotobuf系か判定 */
+    protected boolean isProtobufContentType() {
+        try {
+            String contentType = getContentType();
+            return AppEditorProvider.ENABLE_EDITOR_CONTENT_TYPE.stream()
+                    .anyMatch(ctype -> contentType.startsWith(ctype));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String caption() {
+        return editorCaption;
+    }
+
+    public Component uiComponent() {
+        return mainEditorPanel;
+    }
+
+    public Selection selectedData() {
+        return editor.selection().get();
+    }
+
+    public boolean isModified() {
+        return editor.isModified();
+    }
+}

--- a/app/src/main/java/protobufhandler/view/AppRequestEditorView.java
+++ b/app/src/main/java/protobufhandler/view/AppRequestEditorView.java
@@ -3,235 +3,85 @@ package protobufhandler.view;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.message.HttpRequestResponse;
-import burp.api.montoya.logging.Logging;
-import burp.api.montoya.ui.Selection;
-import burp.api.montoya.ui.editor.RawEditor;
-import burp.api.montoya.ui.editor.extension.EditorCreationContext;
 import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.ui.Selection;
+import burp.api.montoya.ui.editor.extension.EditorCreationContext;
 import burp.api.montoya.ui.editor.extension.ExtensionProvidedHttpRequestEditor;
-import protobufhandler.AppEditorProvider;
 import protobufhandler.util.Protobuffer;
 
-import java.awt.BorderLayout;
-import java.awt.FlowLayout;
-import java.awt.Font;
-import java.awt.Color;
 import java.awt.Component;
-
-import javax.swing.JPanel;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JFileChooser;
-import javax.swing.BoxLayout;
-
-import javax.swing.filechooser.FileFilter;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
-import java.util.List;
-import java.util.HashMap;
-import java.util.Objects;
-
 import java.nio.charset.StandardCharsets;
 
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Descriptors.Descriptor;
 
-public class AppRequestEditorView implements ExtensionProvidedHttpRequestEditor {
-    private JPanel mainEditorPanel;
-    private JComboBox<String> messageTypeComboBox;
-    private HttpRequestResponse requestResponse;
-    private HashMap<String, Descriptor> messageTypes;
-    private final RawEditor requestEditor;
-    private final String editorCaption;
-    private final Logging logging;
+public class AppRequestEditorView extends AbstractEditorView implements ExtensionProvidedHttpRequestEditor {
 
     public AppRequestEditorView(MontoyaApi api, EditorCreationContext creationContext, String editorCaption) {
-        logging = api.logging();
-        this.editorCaption = editorCaption;
+        super(api, creationContext, editorCaption);
+    }
 
-        requestEditor = api.userInterface().createRawEditor();
-        requestEditor.setEditable(false);
+    @Override
+    protected byte[] getBodyBytes() {
+        return requestResponse.request().body().getBytes();
+    }
 
-        mainEditorPanel = new JPanel(new BorderLayout());
-        JLabel selectedProtoPathLabel = new JLabel("選択されていません");
-        selectedProtoPathLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
+    @Override
+    protected void onDecodeSuccess(String json) {
+        editor.setEditable(true);
+        editor.setContents(ByteArray.byteArray(json));
+    }
 
-        messageTypeComboBox = new JComboBox<String>();
-        messageTypeComboBox.setEnabled(false);
-
-        JButton protoChooseBtn  = new JButton("Choose");
-        JButton resetBtn        = new JButton("Reset");
-        JButton jsonDecodeBtn   = new JButton("Decode");
-        jsonDecodeBtn.setEnabled(false);
-        resetBtn.setBackground(new Color(251, 180, 196));
-
-        JFileChooser protoChooser = new JFileChooser();
-        protoChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        FileFilter descFilter = new FileNameExtensionFilter("Proto Descriptor files (*.desc)", "desc");
-        protoChooser.setFileFilter(descFilter);
-
-        protoChooseBtn.addActionListener( event -> {
-            int actionAns = protoChooser.showOpenDialog(null);
-            if(actionAns == JFileChooser.APPROVE_OPTION) {
-                messageTypes = new HashMap<String, Descriptor>();
-                messageTypeComboBox.removeAllItems();
-                String selectedPath = protoChooser.getSelectedFile().getAbsolutePath();
-                try {
-                    List<Descriptor> descriptors = Protobuffer.getMessageTypesFromProtoFile(selectedPath);
-                    for (Descriptor descriptor : descriptors) {
-                        messageTypes.put(descriptor.getName(), descriptor);
-                        messageTypeComboBox.addItem(descriptor.getName());
-                    }
-
-                } catch(Exception e) {
-                    logging.logToError(e);
-                    logging.logToOutput("Protobuf file の読み込みに失敗しました。");
-                    logging.logToOutput("File: %s\n".formatted(selectedPath));
-                }
-
-                jsonDecodeBtn.setEnabled(true);
-                messageTypeComboBox.setEnabled(true);
-                selectedProtoPathLabel.setText(selectedPath);
-            }
-        });
-
-        resetBtn.addActionListener(event -> {
-            // reset ui
-            jsonDecodeBtn.setEnabled(false);
-            messageTypeComboBox.removeAllItems();
-            messageTypeComboBox.setEnabled(false);
-            selectedProtoPathLabel.setText("選択されていません");
-
-            // set raw format
-            try {
-                String decodedBody = Protobuffer.decodeRaw(requestResponse.request().body().getBytes());
-                requestEditor.setContents(ByteArray.byteArray(decodedBody));
-                requestEditor.setEditable(false);
-
-            } catch (Exception e) {
-                requestEditor.setContents(requestResponse.request().body());
-                requestEditor.setEditable(false);
-            }
-        });
-
-        jsonDecodeBtn.addActionListener( event -> {
-            Descriptor descriptor = messageTypes.get(messageTypeComboBox.getSelectedItem());
-            try {
-                String json = Protobuffer.protobufToJson(requestResponse.request().body().getBytes(), descriptor);
-                requestEditor.setEditable(true);
-                requestEditor.setContents(ByteArray.byteArray(json));
-
-            } catch(Exception e) {
-                logging.logToError(e);
-                requestEditor.setContents(ByteArray.byteArray("Failed to parse input."));
-            }
-        });
-
-        JPanel protoPathPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        protoPathPanel.add(selectedProtoPathLabel);
-        protoPathPanel.add(protoChooseBtn);
-        protoPathPanel.add(resetBtn);
-
-        JPanel protoDecodePanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        protoDecodePanel.add(messageTypeComboBox);
-        protoDecodePanel.add(jsonDecodeBtn);
-
-        JPanel protobufFormPanel = new JPanel();
-        protobufFormPanel.setLayout(new BoxLayout(protobufFormPanel, BoxLayout.Y_AXIS));
-        protobufFormPanel.add(protoPathPanel);
-        protobufFormPanel.add(protoDecodePanel);
-
-        mainEditorPanel.add(protobufFormPanel, BorderLayout.NORTH);
-        mainEditorPanel.add(requestEditor.uiComponent(), BorderLayout.CENTER);
+    @Override
+    protected String getContentType() {
+        return requestResponse.request().headerValue("Content-Type");
     }
 
     @Override
     public HttpRequest getRequest() {
-        if (requestEditor.isModified()) {
+        if (editor.isModified()) {
             Descriptor descriptor = messageTypes.get(messageTypeComboBox.getSelectedItem());
-            HttpRequest request = requestResponse.request();
             try {
-                DynamicMessage message = Protobuffer.jsonToProtobuf(new String(requestEditor.getContents().getBytes(), StandardCharsets.UTF_8), descriptor);
-                request = request.withBody(ByteArray.byteArray(message.toByteArray()));
-
-                return request;
-
-            } catch(Exception e) {
+                DynamicMessage message = Protobuffer.jsonToProtobuf(
+                        new String(editor.getContents().getBytes(), StandardCharsets.UTF_8), descriptor);
+                return requestResponse.request().withBody(ByteArray.byteArray(message.toByteArray()));
+            } catch (Exception e) {
                 logging.logToError(e);
                 logging.logToOutput("Protobuf メッセージへの変換に失敗しました。\n");
             }
         }
-
         return requestResponse.request();
     }
 
     @Override
     public void setRequestResponse(HttpRequestResponse requestResponse) {
         this.requestResponse = requestResponse;
-        Object comboBoxObj = messageTypeComboBox.getSelectedItem();
-        if(Objects.isNull(comboBoxObj)) {
-            try {
-                String decodedBody = Protobuffer.decodeRaw(requestResponse.request().body().getBytes());
-                requestEditor.setContents(ByteArray.byteArray(decodedBody));
-                requestEditor.setEditable(false);
-
-            } catch (Exception e) {
-                requestEditor.setContents(requestResponse.request().body());
-                requestEditor.setEditable(false);
-            }
-
-        } else { // comboBox で選択されているメッセージタイプでデコードする
-            Descriptor descriptor = messageTypes.get(comboBoxObj);
-            try {
-                String json = Protobuffer.protobufToJson(requestResponse.request().body().getBytes(), descriptor);
-                requestEditor.setEditable(true);
-                requestEditor.setContents(ByteArray.byteArray(json));
-
-            } catch(Exception e) { // デコードに失敗したら、元のリクエストデータをセットする
-                try {
-                    String decodedBody = Protobuffer.decodeRaw(requestResponse.request().body().getBytes());
-                    requestEditor.setContents(ByteArray.byteArray(decodedBody));
-                    requestEditor.setEditable(false);
-    
-                } catch (Exception err) {
-                    requestEditor.setContents(requestResponse.request().body());
-                    requestEditor.setEditable(false);
-                }
-            }
-        }
+        decodeAndDisplay();
     }
 
     @Override
     public boolean isEnabledFor(HttpRequestResponse requestResponse) {
-        HttpRequest request = requestResponse.request();
-        try {
-            String contentType = request.headerValue("Content-Type");
-            return AppEditorProvider.ENABLE_EDITOR_CONTENT_TYPE.stream().anyMatch(ctype -> contentType.startsWith(ctype));
-
-        } catch(Exception e) {
-            return false;
-        }
+        this.requestResponse = requestResponse;
+        return isProtobufContentType();
     }
 
     @Override
     public String caption() {
-        return editorCaption;
+        return super.caption();
     }
 
     @Override
     public Component uiComponent() {
-        return mainEditorPanel;
+        return super.uiComponent();
     }
 
     @Override
-    public Selection selectedData()
-    {
-        return requestEditor.selection().get();
+    public Selection selectedData() {
+        return super.selectedData();
     }
 
     @Override
     public boolean isModified() {
-        return requestEditor.isModified();
+        return super.isModified();
     }
 }

--- a/app/src/main/java/protobufhandler/view/AppResponseEditorView.java
+++ b/app/src/main/java/protobufhandler/view/AppResponseEditorView.java
@@ -1,143 +1,35 @@
 package protobufhandler.view;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
-
-import java.awt.BorderLayout;
-import java.awt.FlowLayout;
-import java.awt.Font;
-import java.awt.Color;
-import java.awt.Component;
-
-import javax.swing.JPanel;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JFileChooser;
-import javax.swing.BoxLayout;
-
-import javax.swing.filechooser.FileFilter;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
-import com.google.protobuf.Descriptors.Descriptor;
-
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.message.HttpRequestResponse;
 import burp.api.montoya.http.message.responses.HttpResponse;
-import burp.api.montoya.logging.Logging;
 import burp.api.montoya.ui.Selection;
-import burp.api.montoya.ui.editor.RawEditor;
 import burp.api.montoya.ui.editor.extension.EditorCreationContext;
 import burp.api.montoya.ui.editor.extension.ExtensionProvidedHttpResponseEditor;
-import protobufhandler.AppEditorProvider;
-import protobufhandler.util.Protobuffer;
 
-public class AppResponseEditorView implements ExtensionProvidedHttpResponseEditor {
-    private JPanel mainEditorPanel;
-    private JComboBox<String> messageTypeComboBox;
-    private HttpRequestResponse requestResponse;
-    private HashMap<String, Descriptor> messageTypes;
-    private final RawEditor responseEditor;
-    private final String editorCaption;
-    private final Logging logging;
+import java.awt.Component;
+
+public class AppResponseEditorView extends AbstractEditorView implements ExtensionProvidedHttpResponseEditor {
 
     public AppResponseEditorView(MontoyaApi api, EditorCreationContext creationContext, String editorCaption) {
-        logging = api.logging();
-        this.editorCaption = editorCaption;
+        super(api, creationContext, editorCaption);
+    }
 
-        responseEditor = api.userInterface().createRawEditor();
-        responseEditor.setEditable(false);
+    @Override
+    protected byte[] getBodyBytes() {
+        return requestResponse.response().body().getBytes();
+    }
 
-        mainEditorPanel = new JPanel(new BorderLayout());
-        JLabel selectedProtoPathLabel = new JLabel("選択されていません");
-        selectedProtoPathLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
+    @Override
+    protected void onDecodeSuccess(String json) {
+        // Response editorはread-only
+        editor.setContents(ByteArray.byteArray(json));
+    }
 
-        messageTypeComboBox = new JComboBox<String>();
-        messageTypeComboBox.setEnabled(false);
-
-        JButton protoChooseBtn  = new JButton("Choose");
-        JButton resetBtn        = new JButton("Reset");
-        JButton jsonDecodeBtn   = new JButton("Decode");
-        jsonDecodeBtn.setEnabled(false);
-        resetBtn.setBackground(new Color(251, 180, 196));
-
-        JFileChooser protoChooser = new JFileChooser();
-        protoChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        FileFilter descFilter = new FileNameExtensionFilter("Proto Descriptor files (*.desc)", "desc");
-        protoChooser.setFileFilter(descFilter);
-
-        protoChooseBtn.addActionListener( event -> {
-            int actionAns = protoChooser.showOpenDialog(null);
-            if(actionAns == JFileChooser.APPROVE_OPTION) {
-                messageTypes = new HashMap<String, Descriptor>();
-                messageTypeComboBox.removeAllItems();
-                String selectedPath = protoChooser.getSelectedFile().getAbsolutePath();
-                try {
-                    List<Descriptor> descriptors = Protobuffer.getMessageTypesFromProtoFile(selectedPath);
-                    for (Descriptor descriptor : descriptors) {
-                        messageTypes.put(descriptor.getName(), descriptor);
-                        messageTypeComboBox.addItem(descriptor.getName());
-                    }
-
-                } catch(Exception e) {
-                    logging.logToError(e);
-                    logging.logToOutput("Protobuf file の読み込みに失敗しました。");
-                    logging.logToOutput("File: %s\n".formatted(selectedPath));
-                }
-
-                jsonDecodeBtn.setEnabled(true);
-                messageTypeComboBox.setEnabled(true);
-                selectedProtoPathLabel.setText(selectedPath);
-            }
-        });
-
-        resetBtn.addActionListener(event -> {
-            // reset ui
-            jsonDecodeBtn.setEnabled(false);
-            messageTypeComboBox.removeAllItems();
-            messageTypeComboBox.setEnabled(false);
-            selectedProtoPathLabel.setText("選択されていません");
-
-            // set raw format
-            try {
-                String decodedBody = Protobuffer.decodeRaw(requestResponse.response().body().getBytes());
-                responseEditor.setContents(ByteArray.byteArray(decodedBody));
-
-            } catch(Exception e) {
-                responseEditor.setContents(requestResponse.response().body());
-            }
-        });
-
-        jsonDecodeBtn.addActionListener( event -> {
-            Descriptor descriptor = messageTypes.get(messageTypeComboBox.getSelectedItem());
-            try {
-                String json = Protobuffer.protobufToJson(requestResponse.response().body().getBytes(), descriptor);
-                responseEditor.setContents(ByteArray.byteArray(json));
-
-            } catch(Exception e) {
-                logging.logToError(e);
-                responseEditor.setContents(ByteArray.byteArray("Failed to parse input."));
-            }
-        });
-
-        JPanel protoPathPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        protoPathPanel.add(selectedProtoPathLabel);
-        protoPathPanel.add(protoChooseBtn);
-        protoPathPanel.add(resetBtn);
-
-        JPanel protoDecodePanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        protoDecodePanel.add(messageTypeComboBox);
-        protoDecodePanel.add(jsonDecodeBtn);
-
-        JPanel protobufFormPanel = new JPanel();
-        protobufFormPanel.setLayout(new BoxLayout(protobufFormPanel, BoxLayout.Y_AXIS));
-        protobufFormPanel.add(protoPathPanel);
-        protobufFormPanel.add(protoDecodePanel);
-
-        mainEditorPanel.add(protobufFormPanel, BorderLayout.NORTH);
-        mainEditorPanel.add(responseEditor.uiComponent(), BorderLayout.CENTER);
+    @Override
+    protected String getContentType() {
+        return requestResponse.response().headerValue("Content-Type");
     }
 
     @Override
@@ -148,64 +40,32 @@ public class AppResponseEditorView implements ExtensionProvidedHttpResponseEdito
     @Override
     public void setRequestResponse(HttpRequestResponse requestResponse) {
         this.requestResponse = requestResponse;
-        Object comboBoxObj = messageTypeComboBox.getSelectedItem();
-        if(Objects.isNull(comboBoxObj)) {
-            try {
-                String decodedBody = Protobuffer.decodeRaw(requestResponse.response().body().getBytes());
-                responseEditor.setContents(ByteArray.byteArray(decodedBody));
-
-            } catch(Exception e) {
-                responseEditor.setContents(requestResponse.response().body());
-            }
-
-        } else { // comboBox で選択されているメッセージタイプでデコードする
-            Descriptor descriptor = messageTypes.get(comboBoxObj);
-            try {
-                String json = Protobuffer.protobufToJson(requestResponse.response().body().getBytes(), descriptor);
-                responseEditor.setContents(ByteArray.byteArray(json));
-
-            } catch(Exception e) { // デコードに失敗したら、元のリクエストデータをセットする
-                try {
-                    String decodedBody = Protobuffer.decodeRaw(requestResponse.response().body().getBytes());
-                    responseEditor.setContents(ByteArray.byteArray(decodedBody));
-    
-                } catch(Exception err) {
-                    responseEditor.setContents(requestResponse.response().body());
-                }
-            }
-        }
+        decodeAndDisplay();
     }
 
     @Override
     public boolean isEnabledFor(HttpRequestResponse requestResponse) {
-        HttpResponse response = requestResponse.response();
-        try {
-            String contentType = response.headerValue("Content-Type");
-            return AppEditorProvider.ENABLE_EDITOR_CONTENT_TYPE.stream().anyMatch(ctype -> contentType.startsWith(ctype));
-            
-        } catch (Exception e) {
-            return false;
-        }
+        this.requestResponse = requestResponse;
+        return isProtobufContentType();
     }
 
     @Override
     public String caption() {
-        return editorCaption;
+        return super.caption();
     }
 
     @Override
     public Component uiComponent() {
-        return mainEditorPanel;
+        return super.uiComponent();
     }
 
     @Override
-    public Selection selectedData()
-    {
-        return responseEditor.selection().get();
+    public Selection selectedData() {
+        return super.selectedData();
     }
 
     @Override
     public boolean isModified() {
-        return responseEditor.isModified();
+        return super.isModified();
     }
 }

--- a/app/src/main/java/protobufhandler/view/MainView.java
+++ b/app/src/main/java/protobufhandler/view/MainView.java
@@ -20,397 +20,115 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.JTable;
 import javax.swing.ButtonGroup;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import java.awt.GridBagLayout;
 import java.awt.GridBagConstraints;
 import java.awt.Component;
 import java.awt.Font;
 import java.awt.Insets;
-import java.awt.event.ActionListener;
-import java.awt.event.ActionEvent;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.filechooser.FileNameExtensionFilter;
 
 import com.google.protobuf.Descriptors.Descriptor;
 
 import java.util.List;
+import java.util.Map;
+import java.util.LinkedHashMap;
 
 public class MainView {
-    private JSplitPane mainPanel;
-    private AppTableModel itemModel;
+    private static final String NO_FILE_SELECTED = "選択されていません";
+    private static final Font LABEL_FONT = new Font(Font.MONOSPACED, Font.PLAIN, 13);
+
+    private final JSplitPane mainPanel;
+    private final AppTableModel itemModel;
+    private final Logging logging;
+
+    // Form components
+    private final JTextField scopeTextField;
+    private final JLabel selectedProtoPathLabel;
+    private final JComboBox<String> messageTypeComboBox;
+    private final JTextArea responseBodyTextArea;
+    private final JRadioButton requestHandlingBtn;
+    private final JRadioButton responseHandlingBtn;
+    private final ButtonGroup handlingScopeBtnGroup;
+    private final JButton itemSaveBtn;
+    private final JButton itemRemoveBtn;
+    private final JButton protoChooseBtn;
+    private final Map<ToolType, JCheckBox> toolScopeCheckBoxes;
 
     public MainView(MontoyaApi api) {
-        Logging logging = api.logging();
+        this.logging = api.logging();
+        this.itemModel = new AppTableModel();
+
         mainPanel = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
         mainPanel.setDividerLocation(0.5);
-        
-        JPanel itemFormPanel = new JPanel(new GridBagLayout());
 
-        JLabel scopeLabel = new JLabel("Scope");
-        scopeLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
-
-        JLabel messageTypeLabel = new JLabel("Message Type");
-        messageTypeLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
-
-        JLabel toolScopeLabel = new JLabel("Tool Scope");
-        toolScopeLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
-
-        JLabel protoDescLabel = new JLabel("Protobuf File");
-        protoDescLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
-
-        JLabel selectedProtoPathLabel = new JLabel("選択されていません");
-        selectedProtoPathLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
-
-        JLabel handlingScopeLabel = new JLabel("Handling Scope");
-        handlingScopeLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
-
-        JLabel responseBodyLabel = new JLabel("(Optional) Replaced Response Body");
-        responseBodyLabel.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
-
-
-        JTextField scopeTextField   = new JTextField(40);
-        JTextArea  responseBodyTextArea  = new JTextArea(8, 1);
-        JScrollPane responseBodyScrollPane = new JScrollPane(responseBodyTextArea);
+        // Form components
+        scopeTextField = new JTextField(40);
         scopeTextField.setEditable(false);
         scopeTextField.setFocusable(false);
-        responseBodyTextArea.setEnabled(false);
 
-        JComboBox<String> messageTypeComboBox = new JComboBox<String>();
+        selectedProtoPathLabel = createLabel(NO_FILE_SELECTED);
+
+        messageTypeComboBox = new JComboBox<>();
         messageTypeComboBox.setEnabled(false);
 
-        JPanel toolScopePanel                   = new JPanel();
-        JCheckBox toolScopeProxyCheckBox        = new JCheckBox("Proxy", false); 
-        JCheckBox toolScopeRepeaterCheckBox     = new JCheckBox("Repeater", false); 
-        JCheckBox toolScopeIntruderCheckBox     = new JCheckBox("Intruder", false);
-        JCheckBox toolScopeScannerCheckBox      = new JCheckBox("Scanner", false);
-        JCheckBox toolScopeExtensionsCheckBox   = new JCheckBox("Extensions", false);
-        toolScopeProxyCheckBox.setEnabled(false);
-        toolScopeRepeaterCheckBox.setEnabled(false);
-        toolScopeIntruderCheckBox.setEnabled(false);
-        toolScopeScannerCheckBox.setEnabled(false);
-        toolScopeExtensionsCheckBox.setEnabled(false);
+        responseBodyTextArea = new JTextArea(8, 1);
+        responseBodyTextArea.setEnabled(false);
 
-        JPanel itemBtnPanel      = new JPanel();
-        JButton itemNewBtn       = new JButton("New");
-        JButton itemSaveBtn      = new JButton("Save");
-        JButton itemRemoveBtn    = new JButton("Remove");
-        JButton protoChooseBtn   = new JButton("Choose File");
+        // Tool scope checkboxes
+        toolScopeCheckBoxes = new LinkedHashMap<>();
+        for (ToolType toolType : AppModel.RULE_TARGE_TOOL_TYPE) {
+            JCheckBox checkBox = new JCheckBox(toolType.toolName(), false);
+            checkBox.setEnabled(false);
+            toolScopeCheckBoxes.put(toolType, checkBox);
+        }
 
+        // Handling scope radio buttons
+        requestHandlingBtn = new JRadioButton("Request", true);
+        responseHandlingBtn = new JRadioButton("Response");
+        requestHandlingBtn.setEnabled(false);
+        responseHandlingBtn.setEnabled(false);
+        handlingScopeBtnGroup = new ButtonGroup();
+        handlingScopeBtnGroup.add(requestHandlingBtn);
+        handlingScopeBtnGroup.add(responseHandlingBtn);
+
+        // Buttons
+        JButton itemNewBtn = new JButton("New");
+        itemSaveBtn = new JButton("Save");
+        itemRemoveBtn = new JButton("Remove");
+        protoChooseBtn = new JButton("Choose File");
         itemSaveBtn.setEnabled(false);
         itemRemoveBtn.setEnabled(false);
         protoChooseBtn.setEnabled(false);
 
+        // File chooser
         JFileChooser protoChooser = new JFileChooser();
         protoChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        FileFilter descFilter = new FileNameExtensionFilter("Proto Descriptor files (*.desc)", "desc");
-        protoChooser.setFileFilter(descFilter);
+        protoChooser.setFileFilter(new FileNameExtensionFilter("Proto Descriptor files (*.desc)", "desc"));
 
-        JPanel handlingScopePanel = new JPanel();
-        ButtonGroup handlingScopeBtnGroup = new ButtonGroup();
-        JRadioButton requestHandlingBtn = new JRadioButton("Request", true);
-        JRadioButton responseHandlingBtn = new JRadioButton("Response");
-        requestHandlingBtn.setEnabled(false);
-        responseHandlingBtn.setEnabled(false);
-        requestHandlingBtn.setText("Request");
-        responseHandlingBtn.setText("Response");
+        // Build form panel
+        JPanel itemFormPanel = buildFormPanel();
 
-        handlingScopeBtnGroup.add(requestHandlingBtn);
-        handlingScopeBtnGroup.add(responseHandlingBtn);
-        
-        handlingScopePanel.add(requestHandlingBtn);
-        handlingScopePanel.add(responseHandlingBtn);
-
-        // Scope Component
-        GridBagConstraints constraints = baseConstraints();
-        constraints.gridy = 1;
-        itemFormPanel.add(scopeLabel, constraints);
-        constraints.gridx = 1;
-        itemFormPanel.add(scopeTextField, constraints);
-
-        // Proto file Component
-        constraints.gridx = 0; constraints.gridy = 2;
-        itemFormPanel.add(protoDescLabel, constraints);
-        constraints.gridx = 1;
-        itemFormPanel.add(protoChooseBtn, constraints);
-        constraints.gridx = 2;
-        itemFormPanel.add(selectedProtoPathLabel, constraints);
-
-        // Message Type Component
-        constraints.gridx = 0; constraints.gridy = 3;
-        itemFormPanel.add(messageTypeLabel, constraints);
-        constraints.gridx = 1;
-        itemFormPanel.add(messageTypeComboBox, constraints);
-
-        // Tool Scope Component
-        constraints.gridx = 0; constraints.gridy = 4;
-        itemFormPanel.add(toolScopeLabel, constraints);
-        toolScopePanel.add(toolScopeProxyCheckBox);
-        toolScopePanel.add(toolScopeRepeaterCheckBox);
-        toolScopePanel.add(toolScopeIntruderCheckBox);
-        toolScopePanel.add(toolScopeScannerCheckBox);
-        toolScopePanel.add(toolScopeExtensionsCheckBox);
-        constraints.gridx = 1;
-        itemFormPanel.add(toolScopePanel, constraints);
-
-        // Handling Scope Component
-        constraints.gridx = 0; constraints.gridy = 6;
-        itemFormPanel.add(handlingScopeLabel, constraints);
-        constraints.gridx = 1;
-        itemFormPanel.add(handlingScopePanel, constraints);
-
-        // Optional Replace Response Body Component
-        constraints.gridx = 0; constraints.gridy = 8;
-        itemFormPanel.add(responseBodyLabel, constraints);
-        constraints.gridx = 1;
-        itemFormPanel.add(responseBodyScrollPane, constraints);
-
-        // Buttons Component
-        constraints = baseConstraints();
-        itemBtnPanel.add(itemNewBtn);
-        itemBtnPanel.add(itemSaveBtn);
-        itemBtnPanel.add(itemRemoveBtn);
-        constraints.gridx = 1;
-        itemFormPanel.add(itemBtnPanel, constraints);
-
-        itemModel = new AppTableModel();
+        // Build table
         JTable itemTable = new JTable(itemModel) {
-            // アイテムを選択した時の動作
             @Override
-            public void changeSelection(int rowIndex, int columnIndex, boolean toggle, boolean extend)
-            {
-                AppModel item = itemModel.get(rowIndex);
-
-                // Clear view
-                messageTypeComboBox.removeAllItems();
-                toolScopeProxyCheckBox.setSelected(false);
-                toolScopeRepeaterCheckBox.setSelected(false);
-                toolScopeIntruderCheckBox.setSelected(false);
-                toolScopeScannerCheckBox.setSelected(false);
-                toolScopeExtensionsCheckBox.setSelected(false);
-
-                // Enabled Component
-                itemSaveBtn.setEnabled(true);
-                itemRemoveBtn.setEnabled(true);
-                protoChooseBtn.setEnabled(true);
-                messageTypeComboBox.setEnabled(true);
-                scopeTextField.setEditable(true);
-                scopeTextField.setFocusable(true);
-                toolScopeProxyCheckBox.setEnabled(true);
-                toolScopeRepeaterCheckBox.setEnabled(true);
-                toolScopeIntruderCheckBox.setEnabled(true);
-                toolScopeScannerCheckBox.setEnabled(true);
-                toolScopeExtensionsCheckBox.setEnabled(true);
-                requestHandlingBtn.setEnabled(true);
-                responseHandlingBtn.setEnabled(true);
-
-                // Setup view
-                scopeTextField.setText(item.getScope());
-                if(item.getProtoDescPath().isEmpty()) {
-                    selectedProtoPathLabel.setText("選択されていません");
-                } else {
-                    selectedProtoPathLabel.setText(item.getProtoDescPath());
-                }
-                
-                responseBodyTextArea.setText(item.getReplaceResponseBody());
-
-                List<String> messageTypes = item.getCachedMessageTypes();
-                for(int i = 0; i < messageTypes.size(); i++) {
-                    messageTypeComboBox.addItem(messageTypes.get(i));
-                    if(messageTypes.get(i).equals(item.getDescriptor().getName())) {
-                        messageTypeComboBox.setSelectedIndex(i);
-                    }
-                }
-
-                for (String toolName : item.getToolScope()) {
-                    if (toolName.equals(ToolType.PROXY.toolName())) {
-                        toolScopeProxyCheckBox.setSelected(true);
-                    } else if (toolName.equals(ToolType.REPEATER.toolName())) {
-                        toolScopeRepeaterCheckBox.setSelected(true);
-                    } else if (toolName.equals(ToolType.INTRUDER.toolName())) {
-                        toolScopeIntruderCheckBox.setSelected(true);
-                    } else if (toolName.equals(ToolType.SCANNER.toolName())) {
-                        toolScopeScannerCheckBox.setSelected(true);
-                    } else if (toolName.equals(ToolType.EXTENSIONS.toolName())) {
-                        toolScopeExtensionsCheckBox.setSelected(true);
-                    }
-                }
-
-                if(item.isRequestHandling()) { // Requestを選択
-                    handlingScopeBtnGroup.setSelected(requestHandlingBtn.getModel(), true);
-                    responseBodyTextArea.setEnabled(false);
-
-                } else { // Responseを選択
-                    handlingScopeBtnGroup.setSelected(responseHandlingBtn.getModel(), true);
-                    responseBodyTextArea.setEnabled(true);
-                }
-
+            public void changeSelection(int rowIndex, int columnIndex, boolean toggle, boolean extend) {
+                populateFormFromModel(itemModel.get(rowIndex));
                 super.changeSelection(rowIndex, columnIndex, toggle, extend);
             }
         };
 
-        protoChooseBtn.addActionListener( event -> {
-            int actionAns = protoChooser.showOpenDialog(null);
-            if(actionAns == JFileChooser.APPROVE_OPTION) {
-                messageTypeComboBox.removeAllItems();
-                String selectedPath = protoChooser.getSelectedFile().getAbsolutePath();
-                try {
-                    List<Descriptor> descriptors = Protobuffer.getMessageTypesFromProtoFile(selectedPath);
-                    for (Descriptor descriptor : descriptors) {
-                        messageTypeComboBox.addItem(descriptor.getName());
-                    }
-                    
-                } catch(Exception e) {
-                    logging.logToError(e);
-                    logging.logToOutput("Protobuf file の読み込みに失敗しました。");
-                    logging.logToOutput("File: %s\n".formatted(selectedPath));
-                }
+        // Event handlers
+        protoChooseBtn.addActionListener(event -> onProtoFileChoose(protoChooser));
+        itemNewBtn.addActionListener(event -> onNewItem());
+        itemSaveBtn.addActionListener(event -> onSaveItem(itemTable));
+        itemRemoveBtn.addActionListener(event -> onRemoveItem(itemTable));
 
-                selectedProtoPathLabel.setText(selectedPath);
-            }
-        });
+        requestHandlingBtn.addActionListener(event -> responseBodyTextArea.setEnabled(false));
+        responseHandlingBtn.addActionListener(event -> responseBodyTextArea.setEnabled(true));
 
-        itemNewBtn.addActionListener( event -> {
-            AppModel item = new AppModel();
-            item.setComment("選択して編集して下さい!!");
-            itemModel.add(item);
-        });
-
-        // 選択したアイテムの保存
-        itemSaveBtn.addActionListener( event -> {
-            int selectedRow = itemTable.getSelectedRow();
-            if (selectedRow < 0) { return; }
-            // Proto file、 Scope が指定されていない場合は保存しない
-            if (selectedProtoPathLabel.getText().equals("選択されていません")) {
-                protoChooseBtn.requestFocus();
-                return;
-            }
-            if (scopeTextField.getText().isBlank()) {
-                scopeTextField.requestFocus();
-                return;
-            }
-
-            AppModel item = itemModel.get(selectedRow);
-            item.clearToolScope();
-            item.clearCachedMessageType();
-
-            if(toolScopeProxyCheckBox.isSelected()) {
-                item.setToolScope(ToolType.PROXY.toolName());
-            } else {
-                item.removeToolScope(ToolType.PROXY.toolName());
-            }
-
-            if(toolScopeRepeaterCheckBox.isSelected()) {
-                item.setToolScope(ToolType.REPEATER.toolName());
-            } else {
-                item.removeToolScope(ToolType.REPEATER.toolName());
-            }
-
-            if(toolScopeIntruderCheckBox.isSelected()) {
-                item.setToolScope(ToolType.INTRUDER.toolName());
-            } else {
-                item.removeToolScope(ToolType.INTRUDER.toolName());
-            }
-            if(toolScopeScannerCheckBox.isSelected()) {
-                item.setToolScope(ToolType.SCANNER.toolName());
-            } else {
-                item.removeToolScope(ToolType.SCANNER.toolName());
-            }
-
-            if(toolScopeExtensionsCheckBox.isSelected()) {
-                item.setToolScope(ToolType.EXTENSIONS.toolName());
-            } else {
-                item.removeToolScope(ToolType.EXTENSIONS.toolName());
-            }
-
-            item.setScope(scopeTextField.getText());
-            item.setProtoDescPath(selectedProtoPathLabel.getText());
-            item.setRequestHandling(requestHandlingBtn.isSelected());
-            if(responseHandlingBtn.isSelected()) { // Replaceが選択されているなら保存
-                item.setReplaceResponseBody(responseBodyTextArea.getText());
-            }
-
-            try {
-                List<Descriptor> descriptors = Protobuffer.getMessageTypesFromProtoFile(selectedProtoPathLabel.getText());
-                Object comboBoxObj = messageTypeComboBox.getSelectedItem();
-                for (Descriptor descriptor : descriptors) {
-                    item.setCachedMessageType(descriptor.getName());
-                    if(descriptor.getName().equals(String.valueOf(comboBoxObj))) {
-                        item.setDescriptor(descriptor);
-                    }
-                }
-
-            } catch(Exception e) {
-                logging.logToError(e);
-                logging.logToOutput("Protobuf file の読み込みに失敗しました。");
-                logging.logToOutput("File: %s\n".formatted(selectedProtoPathLabel.getText()));
-            }
-
-            itemModel.fireTableRowsUpdated(selectedRow, selectedRow);
-        });
-
-        // ラジオボタンのイベント
-        ActionListener radioAction = new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                JRadioButton selecteRadioButton = (JRadioButton) e.getSource();
-                if(selecteRadioButton.getText().equals("Request")) {
-                    responseBodyTextArea.setEnabled(false);
-
-                } else if(selecteRadioButton.getText().equals("Response")) {
-                    responseBodyTextArea.setEnabled(true);
-                }
-            }
-        };
-        requestHandlingBtn.addActionListener(radioAction);
-        responseHandlingBtn.addActionListener(radioAction);
-
-        // 選択したアイテムの削除
-        itemRemoveBtn.addActionListener( e -> {
-            int selectedRow = itemTable.getSelectedRow();
-            if (selectedRow < 0) { return; }
-            itemModel.remove(selectedRow);
-
-            if (selectedRow - 1 >= 0) {
-                itemTable.setRowSelectionInterval(selectedRow - 1, selectedRow - 1);
-                itemTable.changeSelection(selectedRow - 1, selectedRow - 1, false, false);
-
-            } else if (selectedRow - 1 < 0 && itemTable.getRowCount() > 0) {
-                itemTable.setRowSelectionInterval(0, 0);
-                itemTable.changeSelection(0, 0, false, false);
-
-            } else {
-                // Clear view
-                messageTypeComboBox.removeAllItems();
-                scopeTextField.setText("");
-                responseBodyTextArea.setText("");
-                selectedProtoPathLabel.setText("選択されていません");
-                toolScopeProxyCheckBox.setSelected(false);
-                toolScopeRepeaterCheckBox.setSelected(false);
-                toolScopeIntruderCheckBox.setSelected(false);
-                toolScopeScannerCheckBox.setSelected(false);
-                toolScopeExtensionsCheckBox.setSelected(false);
-                handlingScopeBtnGroup.setSelected(requestHandlingBtn.getModel(), true);
-
-                // Disable Component
-                scopeTextField.setEditable(false);
-                scopeTextField.setFocusable(false);
-                responseBodyTextArea.setEnabled(false);
-                messageTypeComboBox.setEnabled(false);
-                itemSaveBtn.setEnabled(false);
-                itemRemoveBtn.setEnabled(false);
-                protoChooseBtn.setEnabled(false);
-                toolScopeProxyCheckBox.setEnabled(false);
-                toolScopeRepeaterCheckBox.setEnabled(false);
-                toolScopeIntruderCheckBox.setEnabled(false);
-                toolScopeScannerCheckBox.setEnabled(false);
-                toolScopeExtensionsCheckBox.setEnabled(false);
-                requestHandlingBtn.setEnabled(false);
-                responseHandlingBtn.setEnabled(false);
-            }
-        });
-
-        JScrollPane itemTableScrollPane = new JScrollPane(itemTable);
-        mainPanel.setLeftComponent(itemTableScrollPane);
+        // Layout
+        mainPanel.setLeftComponent(new JScrollPane(itemTable));
         mainPanel.setRightComponent(itemFormPanel);
     }
 
@@ -422,13 +140,248 @@ public class MainView {
         return itemModel.getAll();
     }
 
-    private GridBagConstraints baseConstraints() {
+    // --- Form layout ---
+
+    private JPanel buildFormPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints c = baseConstraints();
+
+        // Scope
+        c.gridy = 1;
+        panel.add(createLabel("Scope"), c);
+        c.gridx = 1;
+        panel.add(scopeTextField, c);
+
+        // Proto file
+        c.gridx = 0; c.gridy = 2;
+        panel.add(createLabel("Protobuf File"), c);
+        c.gridx = 1;
+        panel.add(protoChooseBtn, c);
+        c.gridx = 2;
+        panel.add(selectedProtoPathLabel, c);
+
+        // Message Type
+        c.gridx = 0; c.gridy = 3;
+        panel.add(createLabel("Message Type"), c);
+        c.gridx = 1;
+        panel.add(messageTypeComboBox, c);
+
+        // Tool Scope
+        c.gridx = 0; c.gridy = 4;
+        panel.add(createLabel("Tool Scope"), c);
+        JPanel toolScopePanel = new JPanel();
+        toolScopeCheckBoxes.values().forEach(toolScopePanel::add);
+        c.gridx = 1;
+        panel.add(toolScopePanel, c);
+
+        // Handling Scope
+        c.gridx = 0; c.gridy = 6;
+        panel.add(createLabel("Handling Scope"), c);
+        JPanel handlingScopePanel = new JPanel();
+        handlingScopePanel.add(requestHandlingBtn);
+        handlingScopePanel.add(responseHandlingBtn);
+        c.gridx = 1;
+        panel.add(handlingScopePanel, c);
+
+        // Response Body
+        c.gridx = 0; c.gridy = 8;
+        panel.add(createLabel("(Optional) Replaced Response Body"), c);
+        c.gridx = 1;
+        panel.add(new JScrollPane(responseBodyTextArea), c);
+
+        // Buttons
+        c = baseConstraints();
+        JPanel btnPanel = new JPanel();
+        // itemNewBtn is local, but we need it here — passed via constructor flow
+        // Actually, we add it in the constructor. Let's add a placeholder.
+        c.gridx = 1;
+        panel.add(buildButtonPanel(), c);
+
+        return panel;
+    }
+
+    private JPanel buildButtonPanel() {
+        JPanel panel = new JPanel();
+        JButton itemNewBtn = new JButton("New");
+        itemNewBtn.addActionListener(event -> onNewItem());
+        panel.add(itemNewBtn);
+        panel.add(itemSaveBtn);
+        panel.add(itemRemoveBtn);
+        return panel;
+    }
+
+    // --- Event handlers ---
+
+    private void onProtoFileChoose(JFileChooser protoChooser) {
+        int actionAns = protoChooser.showOpenDialog(null);
+        if (actionAns == JFileChooser.APPROVE_OPTION) {
+            messageTypeComboBox.removeAllItems();
+            String selectedPath = protoChooser.getSelectedFile().getAbsolutePath();
+            try {
+                List<Descriptor> descriptors = Protobuffer.getMessageTypesFromProtoFile(selectedPath);
+                for (Descriptor descriptor : descriptors) {
+                    messageTypeComboBox.addItem(descriptor.getName());
+                }
+            } catch (Exception e) {
+                logging.logToError(e);
+                logging.logToOutput("Protobuf file の読み込みに失敗しました。File: %s".formatted(selectedPath));
+            }
+            selectedProtoPathLabel.setText(selectedPath);
+        }
+    }
+
+    private void onNewItem() {
+        AppModel item = new AppModel();
+        item.setComment("選択して編集して下さい!!");
+        itemModel.add(item);
+    }
+
+    private void onSaveItem(JTable itemTable) {
+        int selectedRow = itemTable.getSelectedRow();
+        if (selectedRow < 0) { return; }
+
+        if (selectedProtoPathLabel.getText().equals(NO_FILE_SELECTED)) {
+            protoChooseBtn.requestFocus();
+            return;
+        }
+        if (scopeTextField.getText().isBlank()) {
+            scopeTextField.requestFocus();
+            return;
+        }
+
+        AppModel item = itemModel.get(selectedRow);
+        item.clearToolScope();
+        item.clearCachedMessageType();
+
+        // Tool scope の保存
+        toolScopeCheckBoxes.forEach((toolType, checkBox) -> {
+            if (checkBox.isSelected()) {
+                item.setToolScope(toolType.toolName());
+            }
+        });
+
+        item.setScope(scopeTextField.getText());
+        item.setProtoDescPath(selectedProtoPathLabel.getText());
+        item.setRequestHandling(requestHandlingBtn.isSelected());
+        if (responseHandlingBtn.isSelected()) {
+            item.setReplaceResponseBody(responseBodyTextArea.getText());
+        }
+
+        try {
+            List<Descriptor> descriptors = Protobuffer.getMessageTypesFromProtoFile(selectedProtoPathLabel.getText());
+            Object comboBoxObj = messageTypeComboBox.getSelectedItem();
+            for (Descriptor descriptor : descriptors) {
+                item.setCachedMessageType(descriptor.getName());
+                if (descriptor.getName().equals(String.valueOf(comboBoxObj))) {
+                    item.setDescriptor(descriptor);
+                }
+            }
+        } catch (Exception e) {
+            logging.logToError(e);
+            logging.logToOutput("Protobuf file の読み込みに失敗しました。File: %s".formatted(selectedProtoPathLabel.getText()));
+        }
+
+        itemModel.fireTableRowsUpdated(selectedRow, selectedRow);
+    }
+
+    private void onRemoveItem(JTable itemTable) {
+        int selectedRow = itemTable.getSelectedRow();
+        if (selectedRow < 0) { return; }
+        itemModel.remove(selectedRow);
+
+        if (selectedRow - 1 >= 0) {
+            itemTable.setRowSelectionInterval(selectedRow - 1, selectedRow - 1);
+            itemTable.changeSelection(selectedRow - 1, selectedRow - 1, false, false);
+        } else if (itemTable.getRowCount() > 0) {
+            itemTable.setRowSelectionInterval(0, 0);
+            itemTable.changeSelection(0, 0, false, false);
+        } else {
+            clearForm();
+            setFormEnabled(false);
+        }
+    }
+
+    // --- Form state management ---
+
+    private void populateFormFromModel(AppModel item) {
+        // Clear
+        messageTypeComboBox.removeAllItems();
+        toolScopeCheckBoxes.values().forEach(cb -> cb.setSelected(false));
+
+        // Enable components
+        setFormEnabled(true);
+
+        // Populate
+        scopeTextField.setText(item.getScope());
+        selectedProtoPathLabel.setText(
+                item.getProtoDescPath().isEmpty() ? NO_FILE_SELECTED : item.getProtoDescPath());
+        responseBodyTextArea.setText(item.getReplaceResponseBody());
+
+        // Message types
+        List<String> messageTypes = item.getCachedMessageTypes();
+        for (int i = 0; i < messageTypes.size(); i++) {
+            messageTypeComboBox.addItem(messageTypes.get(i));
+            if (item.getDescriptor() != null && messageTypes.get(i).equals(item.getDescriptor().getName())) {
+                messageTypeComboBox.setSelectedIndex(i);
+            }
+        }
+
+        // Tool scope
+        for (String toolName : item.getToolScope()) {
+            toolScopeCheckBoxes.forEach((toolType, checkBox) -> {
+                if (toolType.toolName().equals(toolName)) {
+                    checkBox.setSelected(true);
+                }
+            });
+        }
+
+        // Handling scope
+        if (item.isRequestHandling()) {
+            handlingScopeBtnGroup.setSelected(requestHandlingBtn.getModel(), true);
+            responseBodyTextArea.setEnabled(false);
+        } else {
+            handlingScopeBtnGroup.setSelected(responseHandlingBtn.getModel(), true);
+            responseBodyTextArea.setEnabled(true);
+        }
+    }
+
+    private void clearForm() {
+        messageTypeComboBox.removeAllItems();
+        scopeTextField.setText("");
+        responseBodyTextArea.setText("");
+        selectedProtoPathLabel.setText(NO_FILE_SELECTED);
+        toolScopeCheckBoxes.values().forEach(cb -> cb.setSelected(false));
+        handlingScopeBtnGroup.setSelected(requestHandlingBtn.getModel(), true);
+    }
+
+    private void setFormEnabled(boolean enabled) {
+        scopeTextField.setEditable(enabled);
+        scopeTextField.setFocusable(enabled);
+        responseBodyTextArea.setEnabled(enabled && responseHandlingBtn.isSelected());
+        messageTypeComboBox.setEnabled(enabled);
+        itemSaveBtn.setEnabled(enabled);
+        itemRemoveBtn.setEnabled(enabled);
+        protoChooseBtn.setEnabled(enabled);
+        requestHandlingBtn.setEnabled(enabled);
+        responseHandlingBtn.setEnabled(enabled);
+        toolScopeCheckBoxes.values().forEach(cb -> cb.setEnabled(enabled));
+    }
+
+    // --- Utility ---
+
+    private static JLabel createLabel(String text) {
+        JLabel label = new JLabel(text);
+        label.setFont(LABEL_FONT);
+        return label;
+    }
+
+    private static GridBagConstraints baseConstraints() {
         GridBagConstraints constraints = new GridBagConstraints();
-        constraints.insets             = new Insets(10, 4, 2, 10);
-        constraints.anchor             = GridBagConstraints.NORTHWEST;
-        constraints.fill               = GridBagConstraints.HORIZONTAL;
-        constraints.gridx              = 0;
-        constraints.gridy              = 0;
+        constraints.insets = new Insets(10, 4, 2, 10);
+        constraints.anchor = GridBagConstraints.NORTHWEST;
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.gridx = 0;
+        constraints.gridy = 0;
         return constraints;
     }
 }

--- a/app/src/main/java/protobufhandler/view/ui/AppTableModel.java
+++ b/app/src/main/java/protobufhandler/view/ui/AppTableModel.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.ArrayList;
 
 public class AppTableModel extends AbstractTableModel {
-    private final String[] columns = {"Enabled", "Scope", "Replace Scope", "Tool Scope", "Message Type", "File",  "Comment"};
+    private final String[] columns = {"Enabled", "Scope", "Replace Scope", "Tool Scope", "Message Type", "File", "Comment"};
     private final List<AppModel> items;
 
     public AppTableModel() {
@@ -21,13 +21,12 @@ public class AppTableModel extends AbstractTableModel {
     }
 
     @Override
-    public synchronized int getRowCount()
-    {
+    public synchronized int getRowCount() {
         return items.size();
     }
 
     @Override
-    public int getColumnCount() { 
+    public int getColumnCount() {
         return columns.length;
     }
 
@@ -35,70 +34,36 @@ public class AppTableModel extends AbstractTableModel {
     public synchronized Object getValueAt(int rowIndex, int columnIndex) {
         AppModel item = items.get(rowIndex);
 
-        String messageType = "";
-        if(item.getDescriptor() != null) {
-            messageType = item.getDescriptor().getName();
-        }
-
-        String replaceScope = "Response";
-        if(item.isRequestHandling()) {
-            replaceScope = "Request";
-        }
-
-        return switch (columnIndex)
-                {
-                    case 0 -> item.isEnabled();
-                    case 1 -> item.getScope();
-                    case 2 -> replaceScope;
-                    case 3 -> String.join(", ", item.getToolScope());
-                    case 4 -> messageType;
-                    case 5 -> item.getProtoDescPath();
-                    case 6 -> item.getComment();
-                    default -> "";
-                };
+        return switch (columnIndex) {
+            case 0 -> item.isEnabled();
+            case 1 -> item.getScope();
+            case 2 -> item.isRequestHandling() ? "Request" : "Response";
+            case 3 -> String.join(", ", item.getToolScope());
+            case 4 -> item.getDescriptor() != null ? item.getDescriptor().getName() : "";
+            case 5 -> item.getProtoDescPath();
+            case 6 -> item.getComment();
+            default -> "";
+        };
     }
 
     @Override
     public synchronized void setValueAt(Object aValue, int row, int column) {
         AppModel item = items.get(row);
-
         switch (column) {
-            case 0:
-                item.setEnabled(!item.isEnabled());
-                break;
-
-            case 6:
-                item.setComment((String)aValue);
-                break;
-        
-            default:
-                break;
+            case 0 -> item.setEnabled(!item.isEnabled());
+            case 6 -> item.setComment((String) aValue);
+            default -> {}
         }
     }
 
     @Override
-    public boolean isCellEditable(int row, int column) { 
-        switch (column) {
-            case 0:
-                return true;
-
-            case 6:
-                return true;
-        
-            default:
-                return false;
-        }
+    public boolean isCellEditable(int row, int column) {
+        return column == 0 || column == 6;
     }
 
     @Override
     public Class<?> getColumnClass(int column) {
-        switch (column) {
-            case 0:
-                return Boolean.class;
-        
-            default:
-                return String.class;
-        }
+        return column == 0 ? Boolean.class : String.class;
     }
 
     public synchronized void add(AppModel item) {


### PR DESCRIPTION
## 概要

- **`clearToolScope()` のバグ修正** (`AppModel`) — `toolScope` ではなく `cachedMessageTypes` をクリアしていた問題を修正
- **`AbstractEditorView` 基底クラスの抽出** — `AppRequestEditorView` / `AppResponseEditorView` の約80%の重複コードを共通化 (237+211行 → 87+71行)
- **`MainView` のリファクタリング** — 434行のモノリシックなコンストラクタからメソッドを抽出 (`populateFormFromModel`, `clearForm`, `setFormEnabled` 等)。Tool Scope の CheckBox を `LinkedHashMap` で管理し、繰り返しの if-else ブロックを削除
- **`Protobuffer` のリソースリーク修正** — `FileInputStream` に try-with-resources を適用
- **Java イディオムのモダン化** — double-brace init を `List.of()` に置換、`AppTableModel` で拡張 switch 式を使用、ダイヤモンド演算子の活用
- **`AppHandler` のログ適正化** — スコープ不一致時の冗長な `logToOutput` を削除し、エラーメッセージを1行に集約

**差分: -203行 (812行削除、609行追加、9ファイル変更)**

## テスト計画

- [x] `./gradlew build` が成功することを確認済み
- [ ] Burp Suite で拡張機能をロードし、メイン設定UIが正しく描画されることを確認
- [ ] ハンドリングルールの作成/保存/削除でフォームの状態管理が正しく動作することを確認
- [ ] `.desc` ファイルを読み込み、MainView と Message Editor タブの両方でメッセージタイプの選択が動作することを確認
- [ ] Proxy/Repeater 経由で protobuf リクエストを送信し、JSON↔Protobuf 変換が正しく動作することを確認
- [ ] レスポンスハンドリング (オプションのボディ置換含む) が正しく動作することを確認